### PR TITLE
Add sticky scrolling header

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,10 +1,20 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrolled(window.scrollY > 50);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
 
   return (
-    <header className="site-header">
+    <header className={`site-header${scrolled ? ' scrolled' : ''}`}>
       <div className="container">
         <div className="logo">Logo</div>
         <button

--- a/src/styles.css
+++ b/src/styles.css
@@ -110,6 +110,13 @@ ul {
   left: 0;
   width: 100%;
   z-index: 1000;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.site-header.scrolled {
+  background-color: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .site-header .container {


### PR DESCRIPTION
## Summary
- add scroll detection to header component
- style `site-header.scrolled` with semi-transparent background

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688bdedc83148327a117bdfbac950578