### PR TITLE
Fix hero section alignment

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,11 +1,22 @@
 export default function Hero() {
   return (
     <header className="hero">
-      <h1>Modern Tech<br />Smarter Operations<br />Same Great Business</h1>
-      <p>Helping legacy companies update their systems, technology, and operations — with respect for what’s already working.</p>
-      <div className="buttons">
-        <button className="btn primary">Let’s Talk</button>
-        <button className="btn outline">Book a Discovery Call</button>
+      <div className="container">
+        <h1>
+          Modern Tech
+          <br />
+          Smarter Operations
+          <br />
+          Same Great Business
+        </h1>
+        <p>
+          Helping legacy companies update their systems, technology, and
+          operations — with respect for what’s already working.
+        </p>
+        <div className="buttons">
+          <button className="btn primary">Let’s Talk</button>
+          <button className="btn outline">Book a Discovery Call</button>
+        </div>
       </div>
     </header>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -186,9 +186,7 @@ ul {
 /* Hero Section */
 header.hero {
   margin: 0 auto;
-  padding: 10% 5%;
-  padding-left: calc(5% + var(--spacing-unit) * 2);
-  padding-top: calc(10% + 64px);
+  padding: calc(10% + 64px) 0 10%;
   background-image: radial-gradient(rgba(252, 251, 251, 0.1), rgba(17, 17, 17, 0.5)), url('/hero.jpg');
   background-size: cover;
   background-position: center center;


### PR DESCRIPTION
## Summary
- wrap hero content in a `.container` to match the header
- adjust hero padding in CSS for consistent alignment

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688be5d3be7c8327801b5abf7e8d0e1e