### PR TITLE
Add DM Serif Text for logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Text&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Serif+Text&display=swap');
 
 :root {
   --primary: #f7b018;
@@ -134,6 +135,7 @@ ul {
 .site-header .logo {
   font-weight: 600;
   font-size: 1.25rem;
+  font-family: 'DM Serif Text', serif;
 }
 
 .site-header nav {


### PR DESCRIPTION
## Summary
- load DM Serif Text from Google Fonts
- apply DM Serif Text font to the logo in the header

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c08625cd4832797ab2e662f1fcd60