### PR TITLE
Enable menu dropdown on hover

### DIFF
--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -59,6 +59,11 @@
   display: block;
 }
 
+/* Show the dropdown when hovering over the menu button */
+.menu-toggle:hover + nav {
+  display: block;
+}
+
 .site-header nav ul {
   display: block;
 }


### PR DESCRIPTION
## Summary
- fix header dropdown hover styles so nav displays when hovering over the menu icon

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c2c64b3f08327b9562d4c986946ae