### PR TITLE
Add clickable header menu toggle

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 
 export default function Header() {
   const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
     // Listen to window scroll position
@@ -14,6 +15,10 @@ export default function Header() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  const toggleMenu = () => {
+    setMenuOpen((open) => !open);
+  };
+
   return (
     // Apply 'scrolled' class to header based on scroll position
     <header className={`site-header${scrolled ? ' scrolled' : ''}`}>
@@ -24,11 +29,12 @@ export default function Header() {
         <button
           className={`menu-toggle${scrolled ? ' scrolled' : ''}`}
           aria-label="Menu"
+          onClick={toggleMenu}
         >
-          <span className="material-icons">menu</span>
+          <span className="material-icons">{menuOpen ? 'close' : 'menu'}</span>
         </button>
 
-        <nav>
+        <nav className={menuOpen ? 'open' : ''}>
           <ul>
             <li><a href="#about">About Me</a></li>
             <li><a href="#contact">Contact Me</a></li>

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -56,12 +56,9 @@
   background-color: var(--surface);
 }
 
-.site-header nav:hover {
-  display: block;
-}
 
-/* Show the dropdown when hovering over the menu button */
-.menu-toggle:hover + nav {
+/* Show the dropdown when menu is open */
+.site-header nav.open {
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- implement click toggle for header menu
- swap the menu icon for a close icon when menu is open
- display dropdown only when menu is open

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cdfba5bc88327b02620b5d566a28d