### PR TITLE
Add utility class for bullet lists and update About section

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -4,7 +4,7 @@ export default function About() {
       <div className="container section-content">
         <h2>You’ve Built a Business That Lasts. Now Let’s Make It Easy to Run.</h2>
         <p>Your business has stood the test of time — but behind the scenes, things might feel clunky:</p>  
-        <ul className="list-disc pl-6">
+        <ul className="list-disc">
             <li>Manual processes</li>
             <li>Overlapping tools</li>
             <li>Teams working around systems instead of with them</li>

--- a/src/components/Why.jsx
+++ b/src/components/Why.jsx
@@ -4,13 +4,13 @@ export default function Why() {
       <div className="container section-content">
         <h2>Why Work With Me in the Age of AI.</h2>
         <p>AI can suggest tools.</p>
-        <p>-> I help you choose the right ones — and actually implement them with your team.</p>
+        <p>&rarr; I help you choose the right ones — and actually implement them with your team.</p>
         <br></br>
         <p>Consultants love strategy decks.</p>
-        <p>-> I roll up my sleeves and help you get it done.</p>
+        <p>&rarr; I roll up my sleeves and help you get it done.</p>
         <br></br>
         <p>You don’t need a expert with a bunch of buzzwords.</p>
-        <p>-> I understand how real businesses run — and what it takes to modernize them respectfully.</p>
+        <p>&rarr; I understand how real businesses run — and what it takes to modernize them respectfully.</p>
         <br></br>
       </div>
     </section>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -39,6 +39,12 @@ ul {
   padding: 0;
 }
 
+/* Utility class to display disc bullets with left padding */
+ul.list-disc {
+  list-style-type: disc;
+  padding-left: calc(var(--spacing-unit) * 3);
+}
+
 .container {
   width: 90%;
   max-width: 960px;


### PR DESCRIPTION
## Summary
- add `.list-disc` utility class to restore bullet styling
- use `.list-disc` in About component and remove Tailwind classes
- encode arrow text in Why component to satisfy lint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6892785016f083279642580a089121cb